### PR TITLE
Integrate line login

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,45 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+class AuthenticationController < ApplicationController
+  skip_before_action :authenticate_user!, only: :line_callback
+
+  def line_callback
+    response = get_line_access_token(params)
+    profile_info = get_line_user_info(response)
+    puts profile_info
+    raise
+  end
+
+  private
+
+  def get_line_access_token(params)
+    uri = URI('https://api.line.me/oauth2/v2.1/token')
+    request = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/x-www-form-urlencoded')
+    request.body = URI.encode_www_form(
+      grant_type: 'authorization_code',
+      code: params["code"],
+      redirect_uri: ENV["REDIRECT"],
+      client_id: ENV["CHANNEL_ID"],
+      client_secret: ENV["CHANNEL_SECRET"],
+    )
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+    return JSON.parse(response.body)
+  end
+
+  def get_line_user_info(response)
+    uri = URI('https://api.line.me/oauth2/v2.1/verify')
+    request = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/x-www-form-urlencoded')
+    request.body = URI.encode_www_form(
+      id_token: response["id_token"],
+      client_id: ENV["CHANNEL_ID"],
+    )
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+    return JSON.parse(response.body)
+  end
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,4 +17,6 @@
   </div>
 <% end %>
 
+<%= render "shared/logins" %>
+
 <%= render "devise/shared/links" %>

--- a/app/views/shared/_logins.html.erb
+++ b/app/views/shared/_logins.html.erb
@@ -1,0 +1,5 @@
+<%# https://developers.line.biz/en/docs/line-login/integrate-line-login/#making-an-authorization-request %>
+
+<%# "u" in the redirect URI section changes the url to an encoded string, which is required by LINE in the params rather than a straight up url %>
+<a href="https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=<%= ENV["CHANNEL_ID"] %>&redirect_uri=<%= u ENV["REDIRECT"] %>&state=<%= session[:state] ||= SecureRandom.hex(16) %>&scope=profile%20openid%20email&nonce=09876xyz" class="btn btn-success text-light">Login with LINE</a>
+<br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
     get :invite, on: :member
   end
 
-
+  get "/authentication/line_callback", to: "authentication#line_callback"
 end

--- a/test/controllers/authentication_controller_test.rb
+++ b/test/controllers/authentication_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AuthenticationControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Implemented LINE login functionality

- You can now login through LINE app
- Collects user's email address and minor profile details from LINE
- Creates a new user with no details other than email and a fake placeholder password (which can be switched to random generation after)
- Logs in right after the authentication