### PR TITLE
Refactor activities and events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -49,22 +49,6 @@ class EventsController < ApplicationController
     end
   end
 
-  # raise
-  # def preview_event_plan
-  #   raise
-  #   # @event = Event.find(params[:id])
-  #   authorize @event
-  #   age_range = session[:age_range]
-  #   num_activities = session[:num_activities].to_i
-
-  #   Rails.logger.info "🔥 Calling AI with Age Range: #{age_range}, Num Activities: #{num_activities}"
-
-  #   @generated_activities = @event.generate_activities_from_ai(age_range, num_activities)
-  #   # Store activities that the user already selected
-  #   @selected_activities = @event.activities
-  #   # raise
-  # end
-
   def regenerate_activity
     event_title = params["event_title"]
     age_range = params["age_range"]
@@ -83,7 +67,9 @@ class EventsController < ApplicationController
     @org_users = current_user.organizations.first.users
 
     @generated_activities = @event.generate_activities_from_ai(age_range, num_activities)
+
     @tasks = @task.content(@generated_activities)
+    raise
     Rails.logger.info "Task: #{@task.inspect}"
     Rails.logger.info "Generated Activities: #{@generated_activities.inspect}"
     Rails.logger.info " @suggestions #{@suggestions.inspect}"

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -66,10 +66,8 @@ class EventsController < ApplicationController
     @task = @event.tasks.new
     @org_users = current_user.organizations.first.users
 
-    @generated_activities = @event.generate_activities_from_ai(age_range, num_activities)
-
+    @generated_activities = @event.generate_activities_from_ai(age_range, num_activities)["activity"]
     @tasks = @task.content(@generated_activities)
-    raise
     Rails.logger.info "Task: #{@task.inspect}"
     Rails.logger.info "Generated Activities: #{@generated_activities.inspect}"
     Rails.logger.info " @suggestions #{@suggestions.inspect}"

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -154,10 +154,6 @@ class EventsController < ApplicationController
     @generated_activities = PreviewEventFluffService.get_initial_activities
     @tasks = PreviewEventFluffService.get_initial_tasks
     @org_users = current_user.organizations.first.users
-
-    # @tasks = @generated_activities.each_with_object({}) do |activity, tasks_hash|
-    #   tasks_hash[activity.title] = task_data[activity.title.to_sym] || []
-    # end
   end
 
   def fake_regenerated_preview

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,6 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
     @users = @event.organization.users
-    raise
     # @activities = Activity.where(event_id: @event)
     @task = @event.tasks.new
     # @suggestions = @task.content(@generated_activities)
@@ -75,7 +74,6 @@ class EventsController < ApplicationController
   end
 
   def save_event_plan
-    authorize @event
     @event = Event.find(params[:event_id])
     authorize @event
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -80,34 +80,26 @@ class EventsController < ApplicationController
 
     activities = params[:activities] || []
 
-    activities.each_with_index do |activity_params, index|
+    activities.each_with_index do |activity, index|
       user = nil
       if params["activity"]["#{index}"] != ""
-        puts "***********"
-        puts params["activity"]["#{index}"].to_i
         user = User.find(params["activity"]["#{index}"].to_i)
       end
 
-      genres = activity_params[:genres].presence || []
       # Find or create the activity
-      activity = Activity.create!(
-        title: activity_params[:title],
-        description: activity_params[:description],
-        age: activity_params[:age],
-        genres: genres
+      new_activity = Activity.create!(
+        title: activity[:title],
+        description: activity[:description],
+        age: activity[:age],
+        instructions: activity[:instructions],
+        materials: activity[:materials]
       )
 
       # Associate the activity with the event using the join table
-      ActivitiesEvent.create!(
-        event: @event,
-        activity: activity,
-        custom_title: activity_params[:custom_title],
-        custom_description: activity_params[:custom_description]
-      )
 
       # Save tasks directly under the event
-      if activity_params[:tasks].present?
-        activity_params[:tasks].each do |task_description|
+      if activity[:tasks].present?
+        activity[:tasks].each do |task_description|
           @task = @event.tasks.new(title: task_description, completed: false)
           @task.save
           @task.tasks_users.create!(user: user) if user
@@ -119,66 +111,6 @@ class EventsController < ApplicationController
     end
 
     redirect_to event_path(@event), notice: 'Event plan saved successfully.'
-
-
-    # all_activities = params[:activities] || []
-    # all_activities.each do |activity_data|
-    #   activity = Activity.create!(
-    #     title: activity_data["title"],
-    #     description: activity_data["description"],
-    #     genres: JSON.parse(activity_data["genres"]),
-    #     age: activity_data["age"]
-    #   )
-    #   ActivitiesEvent.create!(activity: activity, event: @event)
-    # end
-    # flash[:notice] = "Event plan saved successfully!"
-    # # Delete when we have better task creation maybe
-    #   if params[:tasks]
-    #     params[:tasks].each do |key, activity|
-    #       activity.each do |task|
-    #         Task.create!(event: @event, title: task[" "])
-    #       end
-    #   end
-    # end
-
-    # redirect_to event_path(@event)
-    # authorize @event
-
-    # # Save tasks
-    # # Method to parse the suggestions string and return it as an array
-    # def parse_suggestions(suggestions_data)
-    #   # Removing extra characters and parsing the string into an array
-    #   suggestions_data.gsub!(/\[|\]/, '')  # Remove square brackets
-    #   suggestions_data.split(',')          # Split by comma to create an array
-    # end
-
-    # # Method to save the parsed suggestions as tasks
-    # def save_suggestions_as_tasks(parsed_suggestions)
-    #   parsed_suggestions.each do |suggestion|
-    #     task = Task.new(title: suggestion.strip, completed: false, event: @event)
-    #     authorize task
-    #     task.save
-    #   end
-    # end
-    # if !params[:tasks]
-    #   suggestions_data = params[:suggestions]
-    #   parsed_suggestions = parse_suggestions(suggestions_data)
-
-    #   # Save the suggestions as tasks
-    #   save_suggestions_as_tasks(parsed_suggestions)
-    # end
-
-    # @suggestions = params["suggestions"]
-    # params[:activities].each do |activity_params|
-    #   @suggestions[activity_params["title"]].each do |suggestion|
-    #     task = Task.new
-    #     task.title = suggestion.title
-    #     task.completed = false
-    #     task.event = @event
-    #     authorize task
-    #     task.save
-    #   end
-    # end
   end
 
   def regenerated_activities

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,6 +12,7 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
     @users = @event.organization.users
+    raise
     # @activities = Activity.where(event_id: @event)
     @task = @event.tasks.new
     # @suggestions = @task.content(@generated_activities)
@@ -87,7 +88,7 @@ class EventsController < ApplicationController
       end
 
       # Find or create the activity
-      new_activity = Activity.create!(
+      new_activity = @event.activities.create!(
         title: activity[:title],
         description: activity[:description],
         age: activity[:age],

--- a/app/javascript/controllers/preview_event_controller.js
+++ b/app/javascript/controllers/preview_event_controller.js
@@ -5,7 +5,7 @@ const activities = {
     {
       "title": "Easter Egg Hunt",
       "description": "Children search for hidden Easter eggs around the event area.",
-      "step_by_step": ["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"],
+      "instructions": ["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"],
       "materials": ["Plastic eggs", "Small prizes or candy"],
       "genre": "Adventure",
       "age": 3,
@@ -19,7 +19,7 @@ const activities = {
     {
       "title": "Easter Bunny Dance",
       "description": "An energetic dance session led by an instructor dressed as the Easter Bunny.",
-      "step_by_step": ["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"],
+      "instructions": ["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"],
       "materials": ["Easter Bunny costume", "Speakers", "Easter-themed music"],
       "genre": "Dance",
       "age": 4,
@@ -33,7 +33,7 @@ const activities = {
     {
       "title": "Easter Crafting",
       "description": "A hands-on crafting activity where children create Easter decorations.",
-      "step_by_step": ["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"],
+      "instructions": ["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"],
       "materials": ["Craft paper", "Markers", "Stickers", "Glue", "Safety scissors"],
       "genre": "Art",
       "age": 5,
@@ -47,7 +47,7 @@ const activities = {
     {
       "title": "Storytime with Easter Tales",
       "description": "A storytelling session featuring Easter-themed tales.",
-      "step_by_step": ["Set up a comfortable seating area", "Choose a couple of Easter-themed picture books", "Read the stories aloud to the children", "Engage children by asking questions", "Conclude with a group discussion on their favorite parts"],
+      "instructions": ["Set up a comfortable seating area", "Choose a couple of Easter-themed picture books", "Read the stories aloud to the children", "Engage children by asking questions", "Conclude with a group discussion on their favorite parts"],
       "materials": ["Easter-themed picture books"],
       "genre": "Storytelling",
       "age": 3,
@@ -61,7 +61,7 @@ const activities = {
     {
       "title": "Easter Egg Roll Race",
       "description": "A fun race where children roll eggs across the floor.",
-      "step_by_step": ["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"],
+      "instructions": ["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"],
       "materials": ["Plastic eggs", "Plastic spoons", "Markers for lines"],
       "genre": "Games",
       "age": 6,
@@ -75,7 +75,7 @@ const activities = {
     {
       "title": "Easter Egg Decorating",
       "description": "A creative activity where kids decorate eggs with various craft supplies.",
-      "step_by_step": ["Boil the eggs in advance", "Set up a decorating station", "Introduce the decorating tools and supplies", "Assist the kids as needed while they decorate"],
+      "instructions": ["Boil the eggs in advance", "Set up a decorating station", "Introduce the decorating tools and supplies", "Assist the kids as needed while they decorate"],
       "materials": ["Hard-boiled eggs", "Markers", "Stickers", "Glue", "Glitter"],
       "genre": "Arts & Crafts",
       "age": 3,
@@ -88,7 +88,7 @@ const activities = {
     },
     {"title": "Musical Bunny Ears",
       "description": "A fun twist on musical chairs involving bunny ears.",
-      "step_by_step": ["Place bunny ears in a circle on the ground", "Play Easter-themed music", "Have kids walk around the circle", "Stop the music and have kids grab ears to wear"],
+      "instructions": ["Place bunny ears in a circle on the ground", "Play Easter-themed music", "Have kids walk around the circle", "Stop the music and have kids grab ears to wear"],
       "materials": ["Bunny ears", "Music player"],
       "genre": "Music & Movement",
       "age": 3,
@@ -101,7 +101,7 @@ const activities = {
     },
     {"title": "Easter Parade",
       "description": "Kids dress in Easter-themed costumes and parade around the venue.",
-      "step_by_step": ["Provide various costume accessories", "Enable each child to choose and dress up", "Organize them into a simple parade line", "Lead them on a short parade around the venue"],
+      "instructions": ["Provide various costume accessories", "Enable each child to choose and dress up", "Organize them into a simple parade line", "Lead them on a short parade around the venue"],
       "materials": ["Costume accessories", "Bunny ears", "Easter hats"],
       "genre": "Drama",
       "age": 5,
@@ -115,7 +115,7 @@ const activities = {
     {
       "title": "Egg Toss Game",
       "description": "A fun practice in precision where kids toss eggs into baskets.",
-      "step_by_step": ["Set up baskets at varying distances", "Explain how to toss the eggs", "Give each child multiple tries to land in a basket", "Encourage and assist them as needed"],
+      "instructions": ["Set up baskets at varying distances", "Explain how to toss the eggs", "Give each child multiple tries to land in a basket", "Encourage and assist them as needed"],
       "materials": ["Plastic eggs", "Baskets"],
       "genre": "Physical Play",
       "age": 4,
@@ -128,7 +128,7 @@ const activities = {
     },
     {"title": "Easter Sing-Along",
       "description": "An engaging session of singing Easter and spring-themed songs.",
-      "step_by_step": ["Prepare a playlist of Easter-themed songs", "Encourage participation in singing", "Use simple musical instruments for best interaction", "Guide kids through different songs"],
+      "instructions": ["Prepare a playlist of Easter-themed songs", "Encourage participation in singing", "Use simple musical instruments for best interaction", "Guide kids through different songs"],
       "materials": ["Song lyrics sheets", "Musical instruments like tambourines"],
       "genre": "Music & Movement",
       "age": 3,
@@ -142,7 +142,7 @@ const activities = {
     {
       "title": "Easter Bunny Dance",
       "description": "An energetic dance session led by an instructor dressed as the Easter Bunny.",
-      "step_by_step": ["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"],
+      "instructions": ["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"],
       "materials": ["Easter Bunny costume", "Speakers", "Easter-themed music"],
       "genre": "Dance",
       "age": 4,
@@ -191,7 +191,7 @@ export default class extends Controller {
     const randomActivity = otherActivities[Math.floor(Math.random() * otherActivities.length)];
 
     if (randomActivity) {
-      const stepByStepInstructions = randomActivity.step_by_step.map((step, index) => `${index + 1}. ${step}`).join("<br><br>");
+      const stepByStepInstructions = randomActivity.instructions.map((step, index) => `${index + 1}. ${step}`).join("<br><br>");
       const collapseId = `details-${randomActivity.title.replace(/\s+/g, '-').toLowerCase()}`;
       const fullDescription = `
         <div class="card shadow-sm border-0 mb-4 activity-card" data-preview-event-target="activity" data-activity-title="${randomActivity.title}">
@@ -218,10 +218,11 @@ export default class extends Controller {
               </div>
 
               <!-- Hidden fields to preserve activity details -->
-              <input type="hidden" name="activities[][title]" value="${randomActivity.title}">
-              <input type="hidden" name="activities[][description]" value="${randomActivity.description}">
-              <input type="hidden" name="activities[][genres]" value='["${randomActivity.genre}"]'>
-              <input type="hidden" name="activities[][age]" value="${randomActivity.age}">
+          <input type="hidden" name="activities[][title]" value="${randomActivity.title}">
+          <input type="hidden" name="activities[][description]" value="${randomActivity.description}">
+          <input type="hidden" name="activities[][materials]" value='${JSON.stringify(randomActivity.materials)}'>
+          <input type="hidden" name="activities[][instructions]" value='${JSON.stringify(randomActivity.instructions)}'>
+          <input type="hidden" name="activities[][age]" value="${randomActivity.ageRange}">
             </div>
           </div>
         </div>

--- a/app/javascript/controllers/real_preview_event_controller.js
+++ b/app/javascript/controllers/real_preview_event_controller.js
@@ -18,6 +18,8 @@ export default class extends Controller {
   }
 
   replaceActivity(data, ageRange, eventTitle, event) {
+    console.log(data);
+
     const fullDescription = this.fullDescription(data, ageRange, eventTitle);
     const activityElement = event.target.closest("[data-preview-event-target='activity']");
     this.updateTasks(activityElement, data);
@@ -35,6 +37,7 @@ export default class extends Controller {
   }
 
   fullDescription(data, ageRange, eventTitle) {
+    const instructions = data.instructions;
     const stepByStepInstructions = data.instructions.map((step, index) => `${index + 1}. ${step}`).join("<br><br>");
     return `
     <div class="card shadow-sm border-0 mb-4 activity-card" data-preview-event-target="activity" data-activity-title="${data.title}">
@@ -60,13 +63,14 @@ export default class extends Controller {
           <div class="collapse mt-3" id="${data.title.split(" ").join("-")}">
             <p><strong>Step-by-Step Instructions:</strong></p>
             <p>${stepByStepInstructions}</p>
-            <p><strong>Materials:</strong> ${data.materials}</p>
+            <p><strong>Materials:</strong> ${data.materials.join(", ")}</p>
           </div>
 
           <!-- Hidden fields to preserve activity details -->
           <input type="hidden" name="activities[][title]" value="${data.title}">
           <input type="hidden" name="activities[][description]" value="${data.description}">
-          <input type="hidden" name="activities[][genres]" value='["${data.genre}"]'>
+          <input type="hidden" name="activities[][materials]" value='${JSON.stringify(data.materials)}'>
+          <input type="hidden" name="activities[][instructions]" value='${JSON.stringify(instructions)}'>
           <input type="hidden" name="activities[][age]" value="${data.ageRange}">
         </div>
       </div>

--- a/app/javascript/controllers/real_preview_event_controller.js
+++ b/app/javascript/controllers/real_preview_event_controller.js
@@ -37,6 +37,7 @@ export default class extends Controller {
   }
 
   fullDescription(data, ageRange, eventTitle) {
+    const count = Math.floor(Math.random() * 1000000);
     const instructions = data.instructions;
     const stepByStepInstructions = data.instructions.map((step, index) => `${index + 1}. ${step}`).join("<br><br>");
     return `
@@ -57,10 +58,10 @@ export default class extends Controller {
             </button>
           </div>
           <p class="mb-1"><i class="fas fa-info-circle"></i> ${data.description.split("\n\n")[0].replace("**Description**: ", "")}</p>
-          <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#${data.title.split(" ").join("-")}">
+          <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#details${count}">
             <i class="fa-solid fa-circle-chevron-down"></i>
           </button>
-          <div class="collapse mt-3" id="${data.title.split(" ").join("-")}">
+          <div class="collapse mt-3" id="details${count}">
             <p><strong>Step-by-Step Instructions:</strong></p>
             <p>${stepByStepInstructions}</p>
             <p><strong>Materials:</strong> ${data.materials.join(", ")}</p>

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,7 +2,7 @@ class Activity < ApplicationRecord
   has_many :activities_events, dependent: :destroy
   has_many :events, through: :activities_events
 
-  validates :title, :age, :genres, presence: true
+  validates :title, :age, presence: true
 
   include PgSearch::Model
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -127,23 +127,24 @@ class Event < ApplicationRecord
     # AI Prompt
     prompt = <<~PROMPT
       Please provide a list of #{event_details[:num_activities]} fun and engaging activities for an event titled "#{event_details[:title]}" for participants ages from #{event_details[:age_range]} years old.
-      The event duration is #{event_details[:duration]} minutes.
+      The event duration is #{event_details[:duration]} minutes. Each activity's duration added up should total the total event duration.
+
       Format the response in valid JSON as an array of activities, where each activity contains:
       - title (string)
       - description (string)
-      - step_by_step (array of strings)
+      - instructions (array of strings)
       - materials (array of strings)
-      - genre (string)
       - age (integer)
+      - duration in minutes (integer)
 
       Example:
-      { "activities": [
+      { "activity": [
         {
           "title": "Spooky Scavenger Hunt",
           "description": "Participants search for hidden Halloween-themed items.",
-          "step_by_step": ["Hide items", "Divide into teams", "Find items"],
+          "instructions": ["Hide items", "Divide into teams", "Find items"],
           "materials": ["Plastic spiders", "Fake skeletons"],
-          "genre": "Adventure",
+          "duration" : 10,
           "age": 7
         }
       ]}
@@ -164,30 +165,31 @@ class Event < ApplicationRecord
       return []
     end
 
-    activities["activities"].map do |activity_data|
-      title = activity_data["title"] || "Untitled"
-      description = activity_data["description"] || "No description available."
-      step_by_step = activity_data["step_by_step"] || []
-      materials = activity_data["materials"] || []
-      genre = activity_data["genre"] || "General"
-      age = activity_data["age"] || 0
+    activities
+    # activities["activities"].map do |activity_data|
+    #   title = activity_data["title"] || "Untitled"
+    #   description = activity_data["description"] || "No description available."
+    #   step_by_step = activity_data["step_by_step"] || []
+    #   materials = activity_data["materials"] || []
+    #   genre = activity_data["genre"] || "General"
+    #   age = activity_data["age"] || 0
 
-      # Construct full description
-      full_description = <<~DESC
-        **Description**: #{description}
+    #   # Construct full description
+    #   full_description = <<~DESC
+    #     **Description**: #{description}
 
-        **Step-by-Step Instructions**:
-        #{step_by_step.map.with_index(1) { |step, i| "#{i}. #{step}" }.join("\n")}
+    #     **Step-by-Step Instructions**:
+    #     #{step_by_step.map.with_index(1) { |step, i| "#{i}. #{step}" }.join("\n")}
 
-        **Materials**: #{materials.join(', ')}
-      DESC
+    #     **Materials**: #{materials.join(', ')}
+    #   DESC
 
-      Activity.new(
-        title: title,
-        description: full_description,
-        age: age.to_i,
-        genres: [genre] # Convert to an array
-      )
-    end
+    #   Activity.new(
+    #     title: title,
+    #     description: full_description,
+    #     age: age.to_i,
+    #     genres: [genre] # Convert to an array
+    #   )
+    # end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,29 +8,29 @@ class Task < ApplicationRecord
   attr_accessor :user_id, :suggestions
 
   # For OpenAI
-  def content(generated_activities)
-    activity_list =
-       if generated_activities.present?
-         generated_activities.map do |activity|
-           {
-             title: activity["title"],
-             description: activity["description"],
-             age: activity["age"],
-             genres: activity["genres"]
-           }
-         end
-      elsif self.event.activities.present?
-        self.event.activities.map do |activity|
-          {
-            title: activity.title,
-            description: activity.description,
-            age: activity.age,
-            genres: activity.genres
-          }
-        end
-      else
-        []
-      end
+  def content(activity_list)
+    # activity_list =
+    #    if generated_activities.present?
+    #      generated_activities.map do |activity|
+    #        {
+    #          title: activity["title"],
+    #          description: activity["description"],
+    #          age: activity["age"],
+    #          genres: activity["genres"]
+    #        }
+    #      end
+    #   elsif self.event.activities.present?
+    #     self.event.activities.map do |activity|
+    #       {
+    #         title: activity.title,
+    #         description: activity.description,
+    #         age: activity.age,
+    #         genres: activity.genres
+    #       }
+    #     end
+    #   else
+    #     []
+    # end
 
     client = OpenAI::Client.new
     chatgpt_response = client.chat(parameters: {

--- a/app/services/preview_event_fluff_service.rb
+++ b/app/services/preview_event_fluff_service.rb
@@ -60,31 +60,31 @@ class PreviewEventFluffService
 
   def self.get_initial_tasks
     return {
-        "Easter Egg Hunt": [
+        "Easter Egg Hunt" => [
           "Plan venue layout and gather materials (eggs, prizes)",
           "Assign staff for setup and supervision",
           "Hide eggs and prepare gathering area",
           "Explain rules, start hunt, and distribute prizes"
         ],
-        "Easter Bunny Dance": [
+        "Easter Bunny Dance" => [
           "Prepare dance area, sound system, and playlist",
           "Ensure Easter Bunny costume is ready",
           "Lead children in dance activities",
           "Wrap up with a fun dance-off and group photo"
         ],
-        "Easter Crafting": [
+        "Easter Crafting" => [
           "Gather and organize crafting supplies",
           "Set up tables with enough space for participants",
           "Guide children through crafting activities",
           "Display finished crafts and assist with cleanup"
         ],
-        "Storytime with Easter Tales": [
+        "Storytime with Easter Tales" => [
           "Select and review Easter-themed books",
           "Arrange a cozy seating area",
           "Read stories and engage children with questions",
           "Wrap up with a group discussion"
         ],
-        "Easter Egg Roll Race": [
+        "Easter Egg Roll Race" => [
           "Mark race track and prepare materials (eggs, spoons)",
           "Explain race rules to participants",
           "Supervise race and ensure fair play",
@@ -95,19 +95,19 @@ class PreviewEventFluffService
 
   def self.get_saved_tasks
     return {
-        "Easter Egg Hunt": [
+        "Easter Egg Hunt" => [
           "Plan venue layout and gather materials (eggs, prizes)",
           "Assign staff for setup and supervision",
           "Hide eggs and prepare gathering area",
           "Explain rules, start hunt, and distribute prizes"
         ],
-        "Easter Crafting": [
+        "Easter Crafting" => [
           "Gather and organize crafting supplies",
           "Set up tables with enough space for participants",
           "Guide children through crafting activities",
           "Display finished crafts and assist with cleanup"
         ],
-        "Easter Egg Roll Race": [
+        "Easter Egg Roll Race" => [
           "Mark race track and prepare materials (eggs, spoons)",
           "Explain race rules to participants",
           "Supervise race and ensure fair play",
@@ -118,37 +118,37 @@ class PreviewEventFluffService
 
   def self.get_regenerated_tasks
     return {
-      "Easter Egg Decorating": [
+      "Easter Egg Decorating" => [
         "Boil eggs in advance and gather decorating materials",
         "Set up a decorating station with markers, stickers, and glitter",
         "Introduce decorating tools to the kids",
         "Assist children as they decorate their eggs"
       ],
-      "Musical Bunny Ears": [
+      "Musical Bunny Ears" => [
         "Place bunny ears in a circle on the ground",
         "Prepare Easter-themed music and music player",
         "Guide children to walk around the circle while music plays",
         "Stop the music and have children grab bunny ears"
       ],
-      "Easter Parade": [
+      "Easter Parade" => [
         "Provide costume accessories like bunny ears and Easter hats",
         "Help children dress up in their chosen costumes",
         "Organize children into a parade line",
         "Lead the parade around the venue"
       ],
-      "Egg Toss Game": [
+      "Egg Toss Game" => [
         "Set up baskets at various distances",
         "Explain how to toss eggs into the baskets",
         "Give each child multiple tries to land eggs in the baskets",
         "Encourage children and provide assistance if needed"
       ],
-      "Easter Sing-Along": [
+      "Easter Sing-Along" => [
         "Prepare a playlist of Easter and spring songs",
         "Encourage children to participate in singing",
         "Provide tambourines or simple instruments for interaction",
         "Guide children through the songs with fun movements"
       ],
-      "Easter Bunny Dance": [
+      "Easter Bunny Dance" => [
         "Gather children around the dance area and set up music",
         "Dress the instructor in the Easter Bunny costume",
         "Play lively Easter-themed music and demonstrate dance moves",

--- a/app/services/preview_event_fluff_service.rb
+++ b/app/services/preview_event_fluff_service.rb
@@ -1,65 +1,33 @@
 class PreviewEventFluffService
   def self.get_initial_activities
-    activities = {"activities"=>[{"title"=>"Easter Egg Hunt", "description"=>"Children search for hidden Easter eggs around the event area.", "step_by_step"=>["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"], "materials"=>["Plastic eggs", "Small prizes or candy"], "genre"=>"Adventure", "age"=>3}, {"title"=>"Easter Bunny Dance", "description"=>"An energetic dance session led by an instructor dressed as the Easter Bunny.", "step_by_step"=>["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"], "materials"=>["Easter Bunny costume", "Speakers", "Easter-themed music"], "genre"=>"Dance", "age"=>4}, {"title"=>"Easter Crafting", "description"=>"A hands-on crafting activity where children create Easter decorations.", "step_by_step"=>["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"], "materials"=>["Craft paper", "Markers", "Stickers", "Glue", "Safety scissors"], "genre"=>"Art", "age"=>5}, {"title"=>"Storytime with Easter Tales", "description"=>"A storytelling session featuring Easter-themed tales.", "step_by_step"=>["Set up a comfortable seating area", "Choose a couple of Easter-themed picture books", "Read the stories aloud to the children", "Engage children by asking questions", "Conclude with a group discussion on their favorite parts"], "materials"=>["Easter-themed picture books"], "genre"=>"Storytelling", "age"=>3}, {"title"=>"Easter Egg Roll Race", "description"=>"A fun race where children roll eggs across the floor.", "step_by_step"=>["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"], "materials"=>["Plastic eggs", "Plastic spoons", "Markers for lines"], "genre"=>"Games", "age"=>6}]}
+    activities = {"activities"=>[{"title"=>"Easter Egg Hunt", "description"=>"Children search for hidden Easter eggs around the event area.", "instructions"=>["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"], "materials"=>["Plastic eggs", "Small prizes or candy"], "genre"=>"Adventure", "age"=>3}, {"title"=>"Easter Bunny Dance", "description"=>"An energetic dance session led by an instructor dressed as the Easter Bunny.", "instructions"=>["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"], "materials"=>["Easter Bunny costume", "Speakers", "Easter-themed music"], "genre"=>"Dance", "age"=>4}, {"title"=>"Easter Crafting", "description"=>"A hands-on crafting activity where children create Easter decorations.", "instructions"=>["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"], "materials"=>["Craft paper", "Markers", "Stickers", "Glue", "Safety scissors"], "genre"=>"Art", "age"=>5}, {"title"=>"Storytime with Easter Tales", "description"=>"A storytelling session featuring Easter-themed tales.", "instructions"=>["Set up a comfortable seating area", "Choose a couple of Easter-themed picture books", "Read the stories aloud to the children", "Engage children by asking questions", "Conclude with a group discussion on their favorite parts"], "materials"=>["Easter-themed picture books"], "genre"=>"Storytelling", "age"=>3}, {"title"=>"Easter Egg Roll Race", "description"=>"A fun race where children roll eggs across the floor.", "instructions"=>["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"], "materials"=>["Plastic eggs", "Plastic spoons", "Markers for lines"], "genre"=>"Games", "age"=>6}]}
 
     activities = activities["activities"].map do |activity_data|
-      title = activity_data["title"] || "Untitled"
-      description = activity_data["description"] || "No description available."
-      step_by_step = activity_data["step_by_step"] || []
-      materials = activity_data["materials"] || []
-      genre = activity_data["genre"] || "General"
-      age = activity_data["age"] || 0
-
-      # Construct full description
-      full_description = <<~DESC
-        **Description**: #{description}
-
-        **Step-by-Step Instructions**:
-        #{step_by_step.map.with_index(1) { |step, i| "#{i}. #{step}" }.join("\n")}
-
-        **Materials**: #{materials.join(', ')}
-      DESC
-
-      Activity.new(
-        title: title,
-        description: full_description,
-        age: age.to_i,
-        genres: [genre] # Convert to an array
-      )
+      {
+        "title" => activity_data["title"] || "Untitled",
+        "description" => activity_data["description"] || "No description available.",
+        "instructions" => activity_data["instructions"] || [],
+        "materials" => activity_data["materials"] || [],
+        "age" => activity_data["age"] || 0,
+      }
     end
     return activities
   end
 
   def self.get_saved_activities
     activities = {"activities"=>[
-      {"title"=>"Easter Egg Hunt", "description"=>"Children search for hidden Easter eggs around the event area.", "step_by_step"=>["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"], "materials"=>["Plastic eggs", "Small prizes or candy"], "genre"=>"Adventure", "age"=>3},
-      {"title"=>"Easter Crafting", "description"=>"A hands-on crafting activity where children create Easter decorations.", "step_by_step"=>["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"], "materials"=>["Craft paper", "Markers", "Stickers", "Glue", "Safety scissors"], "genre"=>"Art", "age"=>5},
-      {"title"=>"Easter Egg Roll Race", "description"=>"A fun race where children roll eggs across the floor.", "step_by_step"=>["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"], "materials"=>["Plastic eggs", "Plastic spoons", "Markers for lines"], "genre"=>"Games", "age"=>6}]}
+      {"title"=>"Easter Egg Hunt", "description"=>"Children search for hidden Easter eggs around the event area.", "instructions"=>["Hide Easter eggs around the venue", "Explain the rules to the children", "Guide children to start searching", "Encourage all participants to find eggs", "Conclude the hunt and distribute small prizes"], "materials"=>["Plastic eggs", "Small prizes or candy"], "genre"=>"Adventure", "age"=>3},
+      {"title"=>"Easter Crafting", "description"=>"A hands-on crafting activity where children create Easter decorations.", "instructions"=>["Provide each child with a crafting kit", "Guide them through making an Easter basket", "Allow time to decorate the baskets with stickers and colors", "Assist as needed", "Display all the crafted items for everyone to see"], "materials"=>["Craft paper", "Markers", "Stickers", "Glue", "Safety scissors"], "genre"=>"Art", "age"=>5},
+      {"title"=>"Easter Egg Roll Race", "description"=>"A fun race where children roll eggs across the floor.", "instructions"=>["Set up a starting line and a finish line", "Provide each child with a plastic egg and a spoon", "Instruct them on rolling the egg with the spoon", "Start the race with a simple start signal", "Cheer on the participants and celebrate everyone's efforts"], "materials"=>["Plastic eggs", "Plastic spoons", "Markers for lines"], "genre"=>"Games", "age"=>6}]}
 
     activities = activities["activities"].map do |activity_data|
-      title = activity_data["title"] || "Untitled"
-      description = activity_data["description"] || "No description available."
-      step_by_step = activity_data["step_by_step"] || []
-      materials = activity_data["materials"] || []
-      genre = activity_data["genre"] || "General"
-      age = activity_data["age"] || 0
-
-      # Construct full description
-      full_description = <<~DESC
-        **Description**: #{description}
-
-        **Step-by-Step Instructions**:
-        #{step_by_step.map.with_index(1) { |step, i| "#{i}. #{step}" }.join("\n")}
-
-        **Materials**: #{materials.join(', ')}
-      DESC
-
-      Activity.new(
-        title: title,
-        description: full_description,
-        age: age.to_i,
-        genres: [genre] # Convert to an array
-      )
+      {
+        "title" => activity_data["title"] || "Untitled",
+        "description" => activity_data["description"] || "No description available.",
+        "instructions" => activity_data["instructions"] || [],
+        "materials" => activity_data["materials"] || [],
+        "age" => activity_data["age"] || 0,
+      }
     end
 
     return activities
@@ -67,40 +35,24 @@ class PreviewEventFluffService
 
   def self.get_regenerated_activities
     activities = {"activities"=>[
-      {"title"=>"Easter Egg Decorating", "description"=>"A creative activity where kids decorate eggs with various craft supplies.", "step_by_step"=>["Boil the eggs in advance", "Set up a decorating station", "Introduce the decorating tools and supplies", "Assist the kids as needed while they decorate"], "materials"=>["Hard-boiled eggs", "Markers", "Stickers", "Glue", "Glitter"], "genre"=>"Arts & Crafts", "age"=>3},
-      {"title"=>"Musical Bunny Ears", "description"=>"A fun twist on musical chairs involving bunny ears.", "step_by_step"=>["Place bunny ears in a circle on the ground", "Play Easter-themed music", "Have kids walk around the circle", "Stop the music and have kids grab ears to wear"], "materials"=>["Bunny ears", "Music player"], "genre"=>"Music & Movement", "age"=>3},
-      {"title"=>"Easter Parade", "description"=>"Kids dress in Easter-themed costumes and parade around the venue.", "step_by_step"=>["Provide various costume accessories", "Enable each child to choose and dress up", "Organize them into a simple parade line", "Lead them on a short parade around the venue"], "materials"=>["Costume accessories", "Bunny ears", "Easter hats"], "genre"=>"Drama", "age"=>5},
-      {"title"=>"Egg Toss Game", "description"=>"A fun practice in precision where kids toss eggs into baskets.", "step_by_step"=>["Set up baskets at varying distances", "Explain how to toss the eggs", "Give each child multiple tries to land in a basket", "Encourage and assist them as needed"], "materials"=>["Plastic eggs", "Baskets"], "genre"=>"Physical Play", "age"=>4},
-      {"title"=>"Easter Sing-Along", "description"=>"An engaging session of singing Easter and spring-themed songs.", "step_by_step"=>["Prepare a playlist of Easter-themed songs", "Encourage participation in singing", "Use simple musical instruments for best interaction", "Guide kids through different songs"], "materials"=>["Song lyrics sheets", "Musical instruments like tambourines"], "genre"=>"Music & Movement", "age"=>3},
-      {"title"=>"Easter Bunny Dance", "description"=>"An energetic dance session led by an instructor dressed as the Easter Bunny.", "step_by_step"=>["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"], "materials"=>["Easter Bunny costume", "Speakers", "Easter-themed music"], "genre"=>"Dance", "age"=>4},
+      {"title"=>"Easter Egg Decorating", "description"=>"A creative activity where kids decorate eggs with various craft supplies.", "instructions"=>["Boil the eggs in advance", "Set up a decorating station", "Introduce the decorating tools and supplies", "Assist the kids as needed while they decorate"], "materials"=>["Hard-boiled eggs", "Markers", "Stickers", "Glue", "Glitter"], "genre"=>"Arts & Crafts", "age"=>3},
+      {"title"=>"Musical Bunny Ears", "description"=>"A fun twist on musical chairs involving bunny ears.", "instructions"=>["Place bunny ears in a circle on the ground", "Play Easter-themed music", "Have kids walk around the circle", "Stop the music and have kids grab ears to wear"], "materials"=>["Bunny ears", "Music player"], "genre"=>"Music & Movement", "age"=>3},
+      {"title"=>"Easter Parade", "description"=>"Kids dress in Easter-themed costumes and parade around the venue.", "instructions"=>["Provide various costume accessories", "Enable each child to choose and dress up", "Organize them into a simple parade line", "Lead them on a short parade around the venue"], "materials"=>["Costume accessories", "Bunny ears", "Easter hats"], "genre"=>"Drama", "age"=>5},
+      {"title"=>"Egg Toss Game", "description"=>"A fun practice in precision where kids toss eggs into baskets.", "instructions"=>["Set up baskets at varying distances", "Explain how to toss the eggs", "Give each child multiple tries to land in a basket", "Encourage and assist them as needed"], "materials"=>["Plastic eggs", "Baskets"], "genre"=>"Physical Play", "age"=>4},
+      {"title"=>"Easter Sing-Along", "description"=>"An engaging session of singing Easter and spring-themed songs.", "instructions"=>["Prepare a playlist of Easter-themed songs", "Encourage participation in singing", "Use simple musical instruments for best interaction", "Guide kids through different songs"], "materials"=>["Song lyrics sheets", "Musical instruments like tambourines"], "genre"=>"Music & Movement", "age"=>3},
+      {"title"=>"Easter Bunny Dance", "description"=>"An energetic dance session led by an instructor dressed as the Easter Bunny.", "instructions"=>["Gather the children around the dance area", "Introduce the Easter Bunny and demonstrate simple dance moves", "Play lively Easter-themed music", "Encourage children to follow along with the Bunny", "Conclude with a fun dance-off and clapping session"], "materials"=>["Easter Bunny costume", "Speakers", "Easter-themed music"], "genre"=>"Dance", "age"=>4},
       ]}
 
     activities = activities["activities"].sample(2)
 
     activities = activities.map do |activity_data|
-      title = activity_data["title"] || "Untitled"
-      description = activity_data["description"] || "No description available."
-      step_by_step = activity_data["step_by_step"] || []
-      materials = activity_data["materials"] || []
-      genre = activity_data["genre"] || "General"
-      age = activity_data["age"] || 0
-
-      # Construct full description
-      full_description = <<~DESC
-        **Description**: #{description}
-
-        **Step-by-Step Instructions**:
-        #{step_by_step.map.with_index(1) { |step, i| "#{i}. #{step}" }.join("\n")}
-
-        **Materials**: #{materials.join(', ')}
-      DESC
-
-      Activity.new(
-        title: title,
-        description: full_description,
-        age: age.to_i,
-        genres: [genre] # Convert to an array
-      )
+      {
+        "title" => activity_data["title"] || "Untitled",
+        "description" => activity_data["description"] || "No description available.",
+        "instructions" => activity_data["instructions"] || [],
+        "materials" => activity_data["materials"] || [],
+        "age" => activity_data["age"] || 0,
+      }
     end
 
     return activities

--- a/app/services/regenerate_activity_service.rb
+++ b/app/services/regenerate_activity_service.rb
@@ -31,7 +31,7 @@ class RegenerateActivityService
               title: *title of generated activity*,
               description: *simple description of generated activity*,
               instructions: [*array of step by step instructions*],
-              materials: *a string of all the materials*,
+              materials: [*array of materials*],
               tasks: [*array of tasks*]
             }
           PROMPT

--- a/app/views/events/_activities.html.erb
+++ b/app/views/events/_activities.html.erb
@@ -1,40 +1,37 @@
-<div class="card shadow-sm border-0 mb-0 activity-card" data-preview-event-target="activity" data-activity-title="<%= activity.title %>">
+<div class="card shadow-sm border-0 mb-0 activity-card" data-preview-event-target="activity" data-activity-title="<%= activity["title"] %>">
   <div class="card-body" data-controller="real-preview-event">
     <div class="d-flex justify-content-between align-items-center">
       <h4 class="card-title mb-0" data-real-preview-event-target="preview-event">
-        <%= activity.title %>
+        <%= activity["title"] %>
       </h4>
       <button
         data-action="click->real-preview-event#regenerate"
-        data-activity-title="<%= activity.title %>"
+        data-activity-title="<%= activity["title"] %>"
         class="btn btn-link p-0 regenerate-btn"
-        data-age-range="<%= activity.age %>"
+        data-age-range="<%= activity["age"] %>"
         data-event="<%= @event.title %>"
-        data-activity="<%= activity.title %>">
+        data-activity="<%= activity["title"] %>">
         <i class="fa-solid fa-arrows-rotate"></i>
       </button>
     </div>
-    <% description_parts = activity.description.split("\n\n") %>
-    <% main_description = description_parts[0].sub(/\*\*Description\*\*:\s*/, '') %>
-    <% instructions = description_parts[1].to_s.sub(/\*\*Step-by-Step Instructions\*\*:\s*/, '') %>
-    <% materials = description_parts[2].to_s.sub(/\*\*Materials\*\*:\s*/, '') %>
-    <p class="mb-1"><i class="fas fa-info-circle"></i> <%= main_description %></p>
-    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#details-<%= activity.title.parameterize %>">
+    <p class="mb-1"><i class="fas fa-info-circle"></i> <%= activity["description"] %></p>
+    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#details-<%= index %>">
       <i class="fa-solid fa-circle-chevron-down"></i>
     </button>
     <!-- Collapsible details -->
-    <div class="collapse mt-3" id="details-<%= activity.title.parameterize %>">
+    <div class="collapse mt-3" id="details-<%= index %>">
       <p><strong>Step-by-Step Instructions:</strong></p>
-      <% instructions.split("\n").each do |step| %>
-        <p><%= step %></p>
-      <% end %>
-      <p><strong>Materials:</strong> <%= materials %></p>
+        <% activity["instructions"].each_with_index do |i, i_index| %>
+          <p><%= i_index + 1 %>. <%= i %></p>
+        <% end %>
+      <p><strong>Materials:</strong> <%= activity["materials"].join(", ") %></p>
     </div>
 
     <!-- Hidden fields to preserve activity details -->
-    <input type="hidden" name="activities[][title]" value="<%= activity.title %>">
-    <input type="hidden" name="activities[][description]" value="<%= activity.description %>">
-    <input type="hidden" name="activities[][genres]" value="<%= activity.genres.to_json %>">
-    <input type="hidden" name="activities[][age]" value="<%= activity.age %>">
+    <input type="hidden" name="activities[][title]" value="<%= activity["title"] %>">
+    <input type="hidden" name="activities[][description]" value="<%= activity["description"] %>">
+    <input type="hidden" name="activities[][materials]" value="<%= activity["materials"].to_json %>">
+    <input type="hidden" name="activities[][instructions]" value="<%= activity["instructions"].to_json %>">
+    <input type="hidden" name="activities[][age]" value="<%= activity["age"] %>">
   </div>
 </div>

--- a/app/views/events/_activity_details.html.erb
+++ b/app/views/events/_activity_details.html.erb
@@ -8,7 +8,7 @@
         <div class="modal-header">
           <%# Title %>
           <h5 class="modal-title" id="activityModalLabel-<%= activity.id %>">
-            <%= activity.display_title.capitalize %>
+            <%= activity.title.capitalize %>
           </h5>
 
           <%# Edit button %>
@@ -35,18 +35,13 @@
           <%# Description Summary %>
           <h5>Description:</h5>
           <div class="modal-cards">
-          <% if activity.display_description.include?("**Description**") %>
-            <% description_summary = activity.display_description.match(/\*\*Description\*\*\s*:\s*(.+?)(?:\*\*|\z)/m)&.captures&.first&.strip %>
-            <p><%= description_summary %></p>
-          <% end %>
+            <p><%= activity.description %></p>
 
-          <%# Description Step-by-Step Instructions %>
-          <% if activity.display_description.include?("**Step-by-Step Instructions**") %>
+            <%# Description Step-by-Step Instructions %>
             <h5>Step-by-Step Instructions:</h5>
             <ul>
-              <% steps = activity.display_description.scan(/\d+\.\s(.+)/)%>
-              <% steps.each do |step| %>
-                <li><%= step.first %></li>
+              <% JSON.parse(activity.instructions).each_with_index do |step, index| %>
+                <li><%= index + 1 %>. <%= step %></li>
               <% end %>
             </ul>
 
@@ -65,22 +60,17 @@
                 <%# </div> %>
               <%# <% end %>
             <%# </div> %>
-
           </div>
-          <% end %>
 
           <%# Materials %>
-              <h5>Materials:</h5>
+          <h5>Materials:</h5>
           <div class="modal-cards">
-            <% if activity.display_description.include?("**Materials**") %>
-              <ul>
-                <% activity.display_description.scan(/\*\*Materials\*\*: (.+)/).each do |material| %>
-                  <% material.first.split(', ').each do |item| %>
-                    <li><%= item.strip %></li>
-                  <% end %>
-                <% end %>
-              </ul>
-            <% end %>
+            <ul>
+              <% JSON.parse(activity.materials).each do |material| %>
+                <li><%= material %></li>
+              <% end %>
+            </ul>
+
           </div>
 
         </div>

--- a/app/views/events/_activity_details.html.erb
+++ b/app/views/events/_activity_details.html.erb
@@ -1,5 +1,5 @@
 
-<div class="modal fade" id="activityModal-<%= activity_event.id %>" tabindex="-1" aria-labelledby="activityModalLabel" aria-hidden="true">
+<div class="modal fade" id="activityModal-<%= activity.id %>" tabindex="-1" aria-labelledby="activityModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <%# stimulus %>
@@ -7,8 +7,8 @@
 
         <div class="modal-header">
           <%# Title %>
-          <h5 class="modal-title" id="activityModalLabel-<%= activity_event.id %>">
-            <%= activity_event.display_title.capitalize %>
+          <h5 class="modal-title" id="activityModalLabel-<%= activity.id %>">
+            <%= activity.display_title.capitalize %>
           </h5>
 
           <%# Edit button %>
@@ -35,16 +35,16 @@
           <%# Description Summary %>
           <h5>Description:</h5>
           <div class="modal-cards">
-          <% if activity_event.display_description.include?("**Description**") %>
-            <% description_summary = activity_event.display_description.match(/\*\*Description\*\*\s*:\s*(.+?)(?:\*\*|\z)/m)&.captures&.first&.strip %>
+          <% if activity.display_description.include?("**Description**") %>
+            <% description_summary = activity.display_description.match(/\*\*Description\*\*\s*:\s*(.+?)(?:\*\*|\z)/m)&.captures&.first&.strip %>
             <p><%= description_summary %></p>
           <% end %>
 
           <%# Description Step-by-Step Instructions %>
-          <% if activity_event.display_description.include?("**Step-by-Step Instructions**") %>
+          <% if activity.display_description.include?("**Step-by-Step Instructions**") %>
             <h5>Step-by-Step Instructions:</h5>
             <ul>
-              <% steps = activity_event.display_description.scan(/\d+\.\s(.+)/)%>
+              <% steps = activity.display_description.scan(/\d+\.\s(.+)/)%>
               <% steps.each do |step| %>
                 <li><%= step.first %></li>
               <% end %>
@@ -72,9 +72,9 @@
           <%# Materials %>
               <h5>Materials:</h5>
           <div class="modal-cards">
-            <% if activity_event.display_description.include?("**Materials**") %>
+            <% if activity.display_description.include?("**Materials**") %>
               <ul>
-                <% activity_event.display_description.scan(/\*\*Materials\*\*: (.+)/).each do |material| %>
+                <% activity.display_description.scan(/\*\*Materials\*\*: (.+)/).each do |material| %>
                   <% material.first.split(', ').each do |item| %>
                     <li><%= item.strip %></li>
                   <% end %>

--- a/app/views/events/_create_event.html.erb
+++ b/app/views/events/_create_event.html.erb
@@ -18,7 +18,7 @@
         <%= f.input :title, label: "Event Title", input_html: { class: "form-control", placeholder: "Enter event name..." } %>
 
         <%= f.input :age_range, collection: ['Kindergarten', 'Elementary', 'High School', 'University', 'Corporate'],
-          label: 'Participants Age Group', input_html: { class: "form-select" } %>
+          label: 'Participants Age Group', input_html: { class: "form-select" }, selected: 'Kindergarten' %>
 
         <%= f.input :duration, label: "Duration (minutes)",
           input_html: { class: "form-control", placeholder: "e.g. 60", type: "number", min: 1 } %>

--- a/app/views/events/_fake_activities.html.erb
+++ b/app/views/events/_fake_activities.html.erb
@@ -5,7 +5,7 @@
         <%= activity["title"] %>
       </h4>
       <button
-        data-action="click->real-preview-event#regenerate"
+        data-action="click->preview-event#regenerate"
         data-activity-title="<%= activity["title"] %>"
         class="btn btn-link p-0 regenerate-btn"
         data-age-range="<%= activity["age"] %>"

--- a/app/views/events/_fake_activities.html.erb
+++ b/app/views/events/_fake_activities.html.erb
@@ -1,37 +1,37 @@
-<div class="card shadow-sm border-0 mb-0 activity-card" data-preview-event-target="activity" data-activity-title="<%= activity.title %>">
+<div class="card shadow-sm border-0 mb-0 activity-card" data-preview-event-target="activity" data-activity-title="<%= activity["title"] %>">
   <div class="card-body" data-controller="preview-event">
     <div class="d-flex justify-content-between align-items-center">
       <h4 class="card-title mb-0" data-target="preview-event">
-        <%= activity.title %>
+        <%= activity["title"] %>
       </h4>
       <button
-        data-action="click->preview-event#regenerate"
-        data-activity-title="<%= activity.title %>"
-        class="btn btn-link p-0 regenerate-btn">
+        data-action="click->real-preview-event#regenerate"
+        data-activity-title="<%= activity["title"] %>"
+        class="btn btn-link p-0 regenerate-btn"
+        data-age-range="<%= activity["age"] %>"
+        data-event="<%= @event.title %>"
+        data-activity="<%= activity["title"] %>">
         <i class="fa-solid fa-arrows-rotate"></i>
       </button>
     </div>
-    <% description_parts = activity.description.split("\n\n") %>
-    <% main_description = description_parts[0].sub(/\*\*Description\*\*:\s*/, '') %>
-    <% instructions = description_parts[1].to_s.sub(/\*\*Step-by-Step Instructions\*\*:\s*/, '') %>
-    <% materials = description_parts[2].to_s.sub(/\*\*Materials\*\*:\s*/, '') %>
-    <p class="mb-1"><i class="fas fa-info-circle"></i> <%= main_description %></p>
-    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#details-<%= activity.title.parameterize %>">
+    <p class="mb-1"><i class="fas fa-info-circle"></i> <%= activity["description"] %></p>
+    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#details-<%= index %>">
       <i class="fa-solid fa-circle-chevron-down"></i>
     </button>
     <!-- Collapsible details -->
-    <div class="collapse mt-3" id="details-<%= activity.title.parameterize %>">
+    <div class="collapse mt-3" id="details-<%= index %>">
       <p><strong>Step-by-Step Instructions:</strong></p>
-      <% instructions.split("\n").each do |step| %>
-        <p><%= step %></p>
-      <% end %>
-      <p><strong>Materials:</strong> <%= materials %></p>
+        <% activity["instructions"].each_with_index do |i, i_index| %>
+          <p><%= i_index + 1 %>. <%= i %></p>
+        <% end %>
+      <p><strong>Materials:</strong> <%= activity["materials"].join(", ") %></p>
     </div>
 
     <!-- Hidden fields to preserve activity details -->
-    <input type="hidden" name="activities[][title]" value="<%= activity.title %>">
-    <input type="hidden" name="activities[][description]" value="<%= activity.description %>">
-    <input type="hidden" name="activities[][genres]" value="<%= activity.genres.to_json %>">
-    <input type="hidden" name="activities[][age]" value="<%= activity.age %>">
+    <input type="hidden" name="activities[][title]" value="<%= activity["title"] %>">
+    <input type="hidden" name="activities[][description]" value="<%= activity["description"] %>">
+    <input type="hidden" name="activities[][materials]" value="<%= activity["materials"].to_json %>">
+    <input type="hidden" name="activities[][instructions]" value="<%= activity["instructions"].to_json %>">
+    <input type="hidden" name="activities[][age]" value="<%= activity["age"] %>">
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -42,20 +42,20 @@
   <%# Activities %>
   <div class="activity-container row my-3">
     <h2>Activities:</h2>
-    <% if  @event.activities_events.any?  %>
-      <% @event.activities_events.each do |activity_event| %>
+    <% if @event.activities.any?  %>
+      <% @event.activities.each do |activity| %>
         <div class="col-3">
 
           <div class="card-pink">
             <div class="card-overview">
-              <p class="text-center"><strong><%= activity_event.display_title.capitalize %></strong></p>
+              <p class="text-center"><strong><%= activity.title.capitalize %></strong></p>
 
               <div class="icon-container d-flex justify-content-between px-2">
                 <%# Details button %>
                 <div class="col-6 text-center">
                   <button type="button" class="btn btn-gradient-oval p-2" data-bs-toggle="modal" data-bs-target="#activityModal-<%= activity_event.id %>">See details</button>
                 </div>
-                <%= render "activity_details", event: @event, activity_event: @activities_events.find_by_id(activity_event.id) %>
+                <%= render "activity_details", event: @event, activity: activity %>
 
                 <%# Delete Activity %>
                 <div class="col-6 text-center">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -53,13 +53,13 @@
               <div class="icon-container d-flex justify-content-between px-2">
                 <%# Details button %>
                 <div class="col-6 text-center">
-                  <button type="button" class="btn btn-gradient-oval p-2" data-bs-toggle="modal" data-bs-target="#activityModal-<%= activity_event.id %>">See details</button>
+                  <button type="button" class="btn btn-gradient-oval p-2" data-bs-toggle="modal" data-bs-target="#activityModal-<%= activity.id %>">See details</button>
                 </div>
                 <%= render "activity_details", event: @event, activity: activity %>
 
                 <%# Delete Activity %>
                 <div class="col-6 text-center">
-                  <%= link_to delete_activity_path(event_id: @event, id: activity_event),class: "no-underline", data: { turbo_method: :delete } do %>
+                  <%= link_to delete_activity_path(event_id: @event, id: activity),class: "no-underline", data: { turbo_method: :delete } do %>
                     <i class="fa-solid fa-trash-can icon-red"></i>
                   <% end %>
                 </div>

--- a/db/migrate/20250305145315_changes_to_activities.rb
+++ b/db/migrate/20250305145315_changes_to_activities.rb
@@ -1,0 +1,8 @@
+class ChangesToActivities < ActiveRecord::Migration[7.1]
+  def change
+    add_column :activities, :instructions, :json, default: []
+    add_column :activities, :materials, :json, default: []
+
+    remove_column :activities, :genres, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_20_095126) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_05_145315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_095126) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.integer "duration"
-    t.json "genres", default: []
+    t.json "instructions", default: []
+    t.json "materials", default: []
   end
 
   create_table "activities_events", force: :cascade do |t|


### PR DESCRIPTION
Minor refactor for now
- Unneeded references (only really activities_events for now) removed from the code, but not from the database yet, as well as most files relating to them
- All activity information is now stored in the activities table (description, instructions, materials, age, title) rather than the activities_events
- Schema updated for the Activity table

Regeneration
- You can now regenerate real and fake events, and their activities and tasks will save as well

The biggest thing to note is that the description (instructions, description, and materials) are no longer in a text field. Each line of text is in their own element (which would make the transition to implementing an edit function easier)