### PR TITLE
Fixing the AI prompt for an edge case

### DIFF
--- a/app/services/regenerate_activity_service.rb
+++ b/app/services/regenerate_activity_service.rb
@@ -26,6 +26,8 @@ class RegenerateActivityService
 
           Please do not include full stops at the end of the instructions and tasks
 
+          Do not include bullet points or numbering in the instructions (i.e. '1.', '2.', 'Step 1', 'Step 2', etc.)
+
           Format the response as valid JSON object
             {
               title: *title of generated activity*,


### PR DESCRIPTION
Added a line to the prompt to try avoid an edge case, where it would give us instructions with numbering and steps when we don't want it, since we do the list numbering ourselves