### PR TITLE
Fixed flatpickr day and preview event styling

### DIFF
--- a/app/assets/stylesheets/components/_create_form.scss
+++ b/app/assets/stylesheets/components/_create_form.scss
@@ -76,7 +76,7 @@
 }
 
 .event-form .flatpickr-day {
-  padding: 0.5rem;  // Adjust day padding for a consistent look
+  // padding: 0.5rem;  // Adjust day padding for a consistent look
 }
 
 .event-form .form-control:focus,

--- a/app/assets/stylesheets/components/_preview_event_plan.scss
+++ b/app/assets/stylesheets/components/_preview_event_plan.scss
@@ -72,3 +72,8 @@
   color: #00b7ff;
   margin-bottom: 1.5rem;
 }
+
+// This makes the scrollbar visible to avoid janky elements moving left when the scrollbar appears
+.preview-scrollbar {
+  overflow-y: scroll;
+}

--- a/app/javascript/controllers/preview_overflow_controller.js
+++ b/app/javascript/controllers/preview_overflow_controller.js
@@ -4,6 +4,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     // This makes the scrollbar visible to avoid janky elements moving left when the scrollbar appears
-    document.querySelector(".overarching-container").classList.add("preview-scrollbar");
+    document.querySelector("body").classList.add("preview-scrollbar");
   }
 }

--- a/app/javascript/controllers/preview_overflow_controller.js
+++ b/app/javascript/controllers/preview_overflow_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="preview-overflow"
+export default class extends Controller {
+  connect() {
+    // This makes the scrollbar visible to avoid janky elements moving left when the scrollbar appears
+    document.querySelector(".overarching-container").classList.add("preview-scrollbar");
+  }
+}

--- a/app/views/events/fake_preview.html.erb
+++ b/app/views/events/fake_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid py-4 px-4 preview-container">
+<div class="container-fluid py-4 px-4 preview-container" data-controller="preview-overflow">
   <div class="text-center mb-4 preview-header">
     <h1 class="fw-bold">Preview Event Plan</h1>
     <h2 class="text-primary"><%= @event.title %></h2>

--- a/app/views/events/preview_event_plan.html.erb
+++ b/app/views/events/preview_event_plan.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid py-4 px-4 preview-container">
+<div class="container-fluid py-4 px-4 preview-container" data-controller="preview-overflow">
   <div class="text-center mb-4 preview-header">
     <h1 class="fw-bold">Preview Event Plan</h1>
     <h2 class="text-primary"><%= @event.title %></h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
   <body data-current-user-id="<%= current_user&.id %>">
     <%= render "shared/navbar" %>
     <%= render "shared/flashes" %>
-    <div class="d-flex flex-column flex-grow-1">
+    <div class="overarching-container d-flex flex-column flex-grow-1">
       <%= yield %>
     </div>
     <%= render "shared/footer" %>


### PR DESCRIPTION
Removed the padding from the flatpickr day that was causing the text to not be centered vertically

Preview event page always has a scrollbar now, as expanding and detracting the elements, leading to increased page height, would cause the scrollbar to push elements left and right, causing some not good visuals