### PR TITLE
Fix activity generation syntax and show page styling

### DIFF
--- a/app/assets/stylesheets/dashboard/_task_section.scss
+++ b/app/assets/stylesheets/dashboard/_task_section.scss
@@ -62,6 +62,7 @@
   right:0;
   top: 50%;
   transform: translateY(-50%);
+  z-index: 100;
 }
 
 .font-small {

--- a/app/assets/stylesheets/event/_show.scss
+++ b/app/assets/stylesheets/event/_show.scss
@@ -398,3 +398,7 @@
   //   box-sizing: border-box;
   // }
 }
+
+.activity-title-text {
+  max-width: 85%;
+}

--- a/app/javascript/controllers/generate_activity_on_show_page_controller.js
+++ b/app/javascript/controllers/generate_activity_on_show_page_controller.js
@@ -69,7 +69,7 @@ export default class extends Controller {
             <i class="fa-solid fa-circle-xmark delete-icon"></i>
           </a>
         </div>
-          <p class="text-center mb-0"><strong>${activity.title}</strong></p>
+          <p class="text-center mb-0 d-flex justify-content-center"><strong class="activity-title-text">${activity.title}</strong></p>
 
           <div class="icon-container d-flex justify-content-evenly px-2">
             <div class="col-6 text-center">

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -138,6 +138,8 @@ class Event < ApplicationRecord
       - age (integer)
       - duration in minutes (integer)
 
+      Please ensure all arrays have closing brackets
+
       Example:
       { "activity": [
         {

--- a/app/services/regenerate_activity_service.rb
+++ b/app/services/regenerate_activity_service.rb
@@ -36,6 +36,8 @@ class RegenerateActivityService
 
           Do not include bullet points or numbering in the instructions (i.e. '1.', '2.', 'Step 1', 'Step 2', etc.)
 
+          Ensure all arrays have closing brackets
+
           Format the response as valid JSON object
             {
               title: *title of generated activity*,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -83,7 +83,7 @@
                     <i class="fa-solid fa-circle-xmark delete-icon"></i>
                   <% end %>
                 </div>
-              <p class="text-center mb-0"><strong><%= activity.title.capitalize %></strong></p>
+              <p class="text-center mb-0 activity-title-text"><strong><%= activity.title.capitalize %></strong></p>
 
               <div class="icon-container d-flex justify-content-evenly px-2">
                 <%# Details button %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -83,7 +83,7 @@
                     <i class="fa-solid fa-circle-xmark delete-icon"></i>
                   <% end %>
                 </div>
-              <p class="text-center mb-0 activity-title-text"><strong><%= activity.title.capitalize %></strong></p>
+              <p class="text-center mb-0 d-flex justify-content-center"><strong class="activity-title-text"><%= activity.title.capitalize %></strong></p>
 
               <div class="icon-container d-flex justify-content-evenly px-2">
                 <%# Details button %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -189,6 +189,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_06_091908) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "username", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "first_name"


### PR DESCRIPTION
Changed the prompts for activity generation to tell them to explicitly generate instructions and materials always with closing brackets

Show page activity title cards have their titles with a smaller max width so they don't conflict with delete button